### PR TITLE
feat: add custom tray and menu and remove default tray

### DIFF
--- a/example/src-tauri/tauri.conf.json
+++ b/example/src-tauri/tauri.conf.json
@@ -18,10 +18,6 @@
     ],
     "security": {
       "csp": null
-    },
-    "trayIcon": {
-      "iconPath": "icons/icon.png",
-      "iconAsTemplate": true
     }
   },
   "bundle": {

--- a/packages/vite-plugin-tauri/src/tauri.ts
+++ b/packages/vite-plugin-tauri/src/tauri.ts
@@ -169,8 +169,19 @@ export function tauri(config?: TauriConfig): PluginOption {
               tauriConfig = {
                 ...tauriConfig,
                 app: {
-                  trayIcon: {
-                    iconAsTemplate: true,
+                  security: {
+                    capabilities: [
+                      {
+                        identifier: 'systemTray',
+                        description: 'Lets app custom configuration for System tray, and menu options',
+                        windows: ['main'],
+                        permissions: [
+                          'core:tray:default',
+                          'core:menu:default',
+                          'core:app:allow-default-window-icon',
+                        ],
+                      },
+                    ],
                   },
                 },
               }
@@ -237,8 +248,19 @@ export function tauri(config?: TauriConfig): PluginOption {
             tauriConfig = {
               ...tauriConfig,
               app: {
-                trayIcon: {
-                  iconAsTemplate: true,
+                security: {
+                  capabilities: [
+                    {
+                      identifier: 'systemTray',
+                      description: 'Lets app custom configuration for System tray, and menu options',
+                      windows: ['main'],
+                      permissions: [
+                        'core:tray:default',
+                        'core:menu:default',
+                        'core:app:allow-default-window-icon',
+                      ],
+                    },
+                  ],
                 },
               },
             }


### PR DESCRIPTION
The console was giving an error related to permissions, just updated the permissions, forcing to have the needed permissions for creating a menu, updating the trayIcon and updating the window default icon

Updated the example because was creating 2 tray icons the custom and the default(the config one on tauri.config.ts)